### PR TITLE
Interpret article-number as alternative pages field.

### DIFF
--- a/source.js
+++ b/source.js
@@ -161,7 +161,7 @@ function cslJournalVolume (csl) {
 }
 
 function cslJournalPage (csl) {
-  return csl['page'];
+  return csl['page'] || csl['article-number']
 }
 
 function cslJournalPublisher (csl) {


### PR DESCRIPTION
Fixes issues with missing pages for APS journals. Apparently they interpret `article-number` as page number, even in their own exports.